### PR TITLE
Fixes bug where allowed file types aren't correctly enforced

### DIFF
--- a/elements/AKH/headers.html
+++ b/elements/AKH/headers.html
@@ -1,2 +1,2 @@
-<link href="https://dd7tel2830j4w.cloudfront.net/f1578765351175x139423091133036980/uppy.min.css" rel="stylesheet">
-<script src="https://dd7tel2830j4w.cloudfront.net/f1578765371467x445963318504138940/uppy.min.js"></script>
+<link href="https://dd7tel2830j4w.cloudfront.net/f1611436067603x979976531106060200/uppy.min-1.24.0.css" rel="stylesheet">
+<script src="https://dd7tel2830j4w.cloudfront.net/f1611435449716x262785717534619550/uppy.min-1.24.0.js"></script>

--- a/elements/AKH/update.js
+++ b/elements/AKH/update.js
@@ -53,6 +53,7 @@ console.log("instance.canvas", instance.canvas)
               maxFileSize: maxFileSize,
               maxNumberOfFiles: maxNumberOfFiles,
               minNumberOfFiles: minNumberOfFiles,
+              allowedFileTypes: allowedFileTypes,
           },
         allowMultipleUploads: allowMultipleUploads,
         autoProceed : autoProceed,

--- a/shared_tech_params.json
+++ b/shared_tech_params.json
@@ -6,11 +6,11 @@
         },
         "ALR": {
             "name": "uppy_css_source",
-            "url": "//dd7tel2830j4w.cloudfront.net/f1578765351175x139423091133036980/uppy.min.css"
+            "url": "//dd7tel2830j4w.cloudfront.net/f1611436067603x979976531106060200/uppy.min-1.24.0.css"
         },
         "ALS": {
             "name": "uppy_js_source",
-            "url": "//dd7tel2830j4w.cloudfront.net/f1578765371467x445963318504138940/uppy.min.js"
+            "url": "//dd7tel2830j4w.cloudfront.net/f1611435449716x262785717534619550/uppy.min-1.24.0.js"
         }
     },
     "dependencies": {


### PR DESCRIPTION
This PR is done on behalf of a client who needs to be able to specify allowed file types to prevent non-HTML5-compatible video files from being uploaded (uppy's default, .mkv, is not HTML5-compatible).

95180c3 adds the array to the restrictions object in uppy settings

7e4df72 Updates the version of Uppy to 1.24.0 (most recent), since there are issues with the existing version that prevents allowedFileTypes from functioning correctly. 1.24.0 still has issues, but they are less severe. See https://github.com/transloadit/uppy/issues/2740